### PR TITLE
MT-01-49

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ function App() {
 
     const dispatch = useDispatch()
     const { reLogin } = userActions
-    const { online } = useSelector(state => state.user)
+    const { online , role} = useSelector(state => state.user)
     const token = JSON.parse(localStorage.getItem("token"))
 
     useEffect(() => {
@@ -46,7 +46,7 @@ function App() {
                 <Route path="/detailsH/:id" element={<DetailsHotels />} />
                 <Route path="/newcity" element={<NewCity />} />
                 <Route path="/newhotel" element={<NewHotel />} />
-                <Route element={<ProtectedRoute isAllowed={!!online} reDirect='/signin' />}>
+                <Route element={<ProtectedRoute isAllowed={!!online && role === 'admin'} reDirect='/signin' />}>
                     <Route path="/mycities" element={<MyCities />} />
                     <Route path="/myhotels" element={<MyHotels />} />
                 </Route>

--- a/src/components/CallToAction.jsx
+++ b/src/components/CallToAction.jsx
@@ -2,11 +2,11 @@ import React from 'react'
 import { Link as NavLink } from 'react-router-dom'
 
 export default function CallToAction(props) {
-    let { rute, classN, text } = props
+    let { rute, classN, text, fx } = props
 
     return (
         <NavLink to={rute} style={{ textDecoration: 'none' }}>
-            <button className={classN}>{text}</button>
+            <button onClick={fx} className={classN}>{text}</button>
         </NavLink>
     )
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,13 +3,17 @@ import { useState } from 'react'
 import ButtonNav from './ButtonNav'
 import CallToAction from './CallToAction'
 import { Link as Navlink } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
+import userActions from '../redux/actions/userActions'
+import Swal from 'sweetalert2'
 
 export default function Navbar() {
 
     let [mostrarOcultar, setMostrarOcultar] = useState(false)
     let [mostrarOcultar2, setMostrarOcultar2] = useState(false)
-    const { online, role } = useSelector(state => state.user)
+    const dispatch = useDispatch()
+    const { online, role, photo, name, token } = useSelector(state => state.user)
+    const { logout } = userActions
 
     let mostrarBoton = () => {
         setMostrarOcultar(!mostrarOcultar)
@@ -19,6 +23,28 @@ export default function Navbar() {
     let mostrarBoton2 = () => {
         setMostrarOcultar2(!mostrarOcultar2)
         setMostrarOcultar(false)
+    }
+
+    function singOut() {
+        Swal.fire({
+            title: 'Are you sure?',
+            text: "You won't be able to revert this!",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#3085d6',
+            cancelButtonColor: '#d33',
+            confirmButtonText: 'Yes, log out!'
+        })
+            .then((result) => {
+                if (result.isConfirmed) {
+                    dispatch(logout(token))
+                    Swal.fire(
+                        'Logged out!',
+                        'You have been logged out',
+                        'success'
+                    )
+                }
+            })
     }
 
     return (
@@ -40,7 +66,16 @@ export default function Navbar() {
                     )}
                 </div>
                 <div>
-                    <ButtonNav buton='User' fx={mostrarBoton2} />
+                    {!online ? (
+                        <ButtonNav buton='User' fx={mostrarBoton2} />
+                    ) : (
+                        <div className='flex column justify-center align-center gap-0-5'>
+                            <img src={photo} width='50' alt="userLoged" onClick={mostrarBoton2}/>
+                            <h5 className='text-white'>{name}</h5>
+                        </div>
+                    )
+
+                    }
                     {mostrarOcultar2 && (
                         <div>
                             {!online && (
@@ -49,11 +84,8 @@ export default function Navbar() {
                                     <CallToAction rute='/signup' classN='btn3' text='SIGN UP' />
                                 </>
                             )}
-                            {role === 'user' && (
-                                <>
-                                    <CallToAction rute='/myitineraries' classN='btn3' text='MY ITINERARY' />
-                                    <CallToAction rute='/myshows' classN='btn3' text='MY SHOWS' />
-                                </>
+                            {online && (
+                                    <CallToAction rute='/myprofile' classN='btn3' text='MY PROFILE' />
                             )}
                             {role === 'admin' && (
                                 <>
@@ -64,7 +96,12 @@ export default function Navbar() {
                                 </>
                             )}
                             {online && (
-                                <CallToAction classN='btn3' text='LOG OUT' />
+                                <>
+                                    <CallToAction rute='/myprofile' classN='btn3' text='MY PROFILE' />
+                                    <CallToAction rute='/myitineraries' classN='btn3' text='MY ITINERARY' />
+                                    <CallToAction rute='/myshows' classN='btn3' text='MY SHOWS' />
+                                    <CallToAction fx={singOut} classN='btn3' text='LOG OUT' />
+                                </>
                             )}
                         </div>
                     )}

--- a/src/redux/actions/userActions.js
+++ b/src/redux/actions/userActions.js
@@ -40,9 +40,26 @@ const reLogin = createAsyncThunk('reLogin', async (token) => {
     }
 })
 
+const logout = createAsyncThunk('logout', async (token) => {
+    let headers = { headers: { 'Authorization': `Bearer ${token}` }}
+    try {
+        let user = await axios.post(`${apiUrl}/api/auth/sign-out`, null, headers)
+        return {
+            success: true,
+            response: user.data.message
+        }
+    } catch (error) {
+        return {
+            success: false,
+            response: error.response.data.message
+        }
+    }
+})
+
 const userActions = {
     login,
-    reLogin
+    reLogin,
+    logout
 }
 
 export default userActions

--- a/src/redux/reducers/userReducer.js
+++ b/src/redux/reducers/userReducer.js
@@ -1,7 +1,7 @@
 import { createReducer } from "@reduxjs/toolkit";
 import userActions from "../actions/userActions";
 
-const { login, reLogin } = userActions;
+const { login, reLogin, logout } = userActions;
 
 const initialState = {
     name: '',
@@ -32,7 +32,16 @@ const userReducers = createReducer(initialState, (builder) => {
             } else {
                 return { ...state, mensaje: response }
             }
-        });
+        })
+        .addCase(logout.fulfilled, (state, action) => {
+            const { success, response } = action.payload;
+            if (success) {
+                localStorage.removeItem("token")
+                return { ...state, name: '', email: '', photo: '', role: '', online: false, token: '' }
+            } else {
+                return { ...state, mensaje: response }
+            }
+        })
 })
 
 export default userReducers


### PR DESCRIPTION
- Se utilizo alerta para confirmar cierre de sesión antes de enviar la petición
- Se renderizo el desplegable de navegación correctamente.
- Se renderizo el desplegable de usuario correctamente.

Evidencia:
![1](https://user-images.githubusercontent.com/99702721/204081706-d2de408c-1ae1-4fb8-92f0-98bd749e72e2.JPG)
![2](https://user-images.githubusercontent.com/99702721/204081709-56b7da24-5e7c-4899-9754-a80594827cd7.JPG)
![3](https://user-images.githubusercontent.com/99702721/204081711-126cdb53-cd7c-4a16-bc99-45148fc1a1d0.JPG)
